### PR TITLE
fix(webpack): 100% ES6 coverage in webpack

### DIFF
--- a/build/webpack/make.js
+++ b/build/webpack/make.js
@@ -1,9 +1,8 @@
-require('babel/register');
 const env   = process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 const merge = require('../../utils/merge-deep');
 
 // Return default configuration extended based on current environment
 module.exports = exports = merge(
   require('./configs/default'),
-  require('./configs/' + env)
+  require(`./configs/${env}`)
 );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,1 +1,2 @@
+require('babel/register');
 module.exports = exports = require('./build/webpack/make');


### PR DESCRIPTION
Moves the babel/register call to `webpack.config.js` so that all webpack-related code is transformed to ES6.