### PR TITLE
Fix/sass hotload

### DIFF
--- a/build/utils/merge-deep.js
+++ b/build/utils/merge-deep.js
@@ -1,0 +1,18 @@
+const extend = (base, extender) => {
+  for (let prop in extender) {
+    if (extender.hasOwnProperty(prop)) {
+      if (
+        typeof base[prop] === 'undefined' ||
+        typeof extender[prop] !== 'object' ||
+        Array.isArray(extender[prop])
+      ) {
+        base[prop] = extender[prop];
+      } else {
+        base[prop] = extend(base[prop], extender[prop]);
+      }
+    }
+  }
+  return base;
+};
+
+module.exports = extend;

--- a/build/webpack/configs/default.js
+++ b/build/webpack/configs/default.js
@@ -2,13 +2,33 @@ const webpack = require('webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const env = process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
+// Hook into the webpack "hot" option to determine whether we're in
+// development or compile mode (NOTE: this cannot rely on the NODE_ENV
+// being "development", since we could theoretically compile the application
+// to disk with the development configuration).
+const HOT_MODE = require('yargs')
+  .default({ hot : false }).argv.hot;
+
+const NODE_ENV = process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+const node_env = NODE_ENV.toLowerCase();
 
 // path helpers
 const root = path.resolve(__dirname, '../../../');
 const resolve = function (localPath) {
   return path.resolve(root, localPath);
 };
+
+// Sass requires different plugins based on the environment -- in development
+// we don't want to use ExtractTextPlugin since it breaks HMR, and dynamically
+// adding/removing it in other configs is more precarious than simply
+// accounting for it here.
+const SASS_LOADERS = [
+  'style-loader',
+  'css-loader',
+  'autoprefixer?browsers=last 2 version',
+  'sass-loader'
+];
 
 module.exports = exports = {
   entry : {
@@ -19,25 +39,26 @@ module.exports = exports = {
   },
   output : {
     path : resolve('dist'),
-    filename : '[name].js'
+    filename : '[name].[hash].js'
   },
   target  : 'web',
   plugins : [
     new webpack.DefinePlugin({
       'process.env' : {
-        'NODE_ENV' : JSON.stringify(env)
+        'NODE_ENV' : JSON.stringify(node_env)
       },
-      '__PROD__' : env === 'production',
-      '__DEV__'  : env === 'development'
+      '__PROD__' : node_env === 'production',
+      '__DEV__'  : node_env === 'development'
     }),
-    new ExtractTextPlugin('[name].[contenthash].css'),
     new HtmlWebpackPlugin({
       template : resolve('app/index.html'),
       hash : true
     }),
-    new webpack.optimize.CommonsChunkPlugin('vendor', '[name].js'),
+    new webpack.optimize.CommonsChunkPlugin('vendor', '[name].[hash].js'),
+    // Don't use ExtractTextPlugin if we're in "hot" mode
+    HOT_MODE ? undefined : new ExtractTextPlugin('[name].[contenthash].css'),
     new webpack.optimize.DedupePlugin()
-  ],
+  ].filter(plugin => typeof plugin !== 'undefined'),
   resolve : {
     extensions : ['', '.js', '.jsx']
   },
@@ -48,19 +69,20 @@ module.exports = exports = {
       loader: 'jshint'
     }],
     loaders : [{
-      test : [/\.js?$/],
+      test : /\.js?$/,
       loaders : ['babel'],
       include : resolve('app')
     }, {
-      test : [/\.scss?$/],
-      loader : ExtractTextPlugin.extract('style-loader', [
-        'css-loader',
-        'autoprefixer?browsers=last 2 version',
-        'sass-loader'
-      ].join('!')),
+      test : /\.scss?$/,
+      // Don't use ExtractTextPlugin if we're in "hot" mode
+      loader : HOT_MODE ?
+        SASS_LOADERS.join('!') :
+        ExtractTextPlugin.extract(
+          SASS_LOADERS[0], SASS_LOADERS.slice(1).join('!')
+        ),
       include : resolve('app')
     }, {
-      test : [/\.jade?$/],
+      test : /\.jade?$/,
       loaders : ['jade'],
       include : resolve('app')
     }]

--- a/build/webpack/configs/production.js
+++ b/build/webpack/configs/production.js
@@ -1,12 +1,8 @@
 const config  = require('./default');
 const webpack = require('webpack');
-const ngAnnotatePlugin = require('ng-annotate-webpack-plugin');
 
 module.exports = exports = {
   plugins : config.plugins.concat([
-    new ngAnnotatePlugin({
-      add: true
-    }),
     new webpack.optimize.UglifyJsPlugin({
       output : {
         'comments'  : false

--- a/build/webpack/make.js
+++ b/build/webpack/make.js
@@ -1,8 +1,6 @@
-const env   = process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-const merge = require('../../utils/merge-deep');
+const merge = require('../utils/merge-deep');
 
-// Return default configuration extended based on current environment
-module.exports = exports = merge(
+module.exports = config => merge(
   require('./configs/default'),
-  require(`./configs/${env}`)
+  require(`./configs/${config}`)
 );

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "setup": "npm install; bower install",
-    "build": "webpack",
-    "build:prod": "NODE_ENV=production webpack",
+    "build": "webpack --make compile",
+    "build:prod": "NODE_ENV=production webpack --make compile",
     "dev": "webpack-dev-server --port 3000 --hot --inline --colors",
     "dev:quiet": "webpack-dev-server --port 3000 --hot --inline --colors --no-info --quiet",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -42,7 +42,8 @@
     "sass-loader": "^1.0.1",
     "style-loader": "^0.12.1",
     "webpack": "^1.9.0",
-    "webpack-dev-server": "^1.8.2"
+    "webpack-dev-server": "^1.8.2",
+    "yargs": "^3.9.0"
   },
   "dependencies": {
     "angular": "^1.3.15",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "setup": "npm install; bower install",
-    "build": "webpack --make compile",
-    "build:prod": "NODE_ENV=production webpack --make compile",
+    "build": "webpack",
+    "build:prod": "NODE_ENV=production webpack",
     "dev": "webpack-dev-server --port 3000 --hot --inline --colors",
     "dev:quiet": "webpack-dev-server --port 3000 --hot --inline --colors --no-info --quiet",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,2 +1,11 @@
+// Determine which webpack configuration to use (defaults to using
+// the current NODE_ENV if no --config flag is provided).
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+const config = require('yargs')
+  .default({ make : process.env.NODE_ENV })
+  .argv
+  .make;
+
+// Compile and export webpack configuration.
 require('babel/register');
-module.exports = exports = require('./build/webpack/make');
+module.exports = exports = require('./build/webpack/make')(config);


### PR DESCRIPTION
This update turns off ExtractTextPlugin when webpack is being run in "hot" mode, as it doesn't work well with HMR (Hot Module Replacement) and can result in broken styles after a rebundle (most likely caused by cascade order being modified).

Also adds the ability to use an argument "--make" to specify what configuration file you use to use _without_ modifying your NODE_ENV.